### PR TITLE
feat(tokens): update color-muted values and add color-emphasis token

### DIFF
--- a/docs/docs/components/rich-text.mdx
+++ b/docs/docs/components/rich-text.mdx
@@ -61,19 +61,19 @@ import "@prokodo/ui/rich-text.css"
 
 `RichText` does not define component-specific CSS custom properties. Override appearance by customising the following global design-system tokens on `:root` or a scoped ancestor:
 
-| Token                       | Description                             |
-| --------------------------- | --------------------------------------- |
-| `--pk-color-brand`          | Link color and ordered list marker fill |
-| `--pk-color-muted`          | Paragraph and code text color           |
-| `--pk-color-fg`             | List item text color                    |
-| `--pk-color-border`         | Code block and blockquote border color  |
-| `--pk-color-surface-raised` | Code block and blockquote background    |
-| `--pk-space-lg`             | Blockquote horizontal padding           |
-| `--pk-space-sm`             | List icon right margin                  |
-| `--pk-space-xs`             | List item bottom gap                    |
-| `--pk-radius-sm`            | Code block corner radius                |
-| `--pk-radius-md`            | Inline image corner radius              |
-| `--pk-palette-white`        | Ordered list marker text color          |
+| Token                       | Description                               |
+| --------------------------- | ----------------------------------------- |
+| `--pk-color-brand`          | Link color and ordered list marker fill   |
+| `--pk-color-muted`          | Paragraph, code, and list item text color |
+| `--pk-color-emphasis`       | Bold / strong text color                  |
+| `--pk-color-border`         | Code block and blockquote border color    |
+| `--pk-color-surface-raised` | Code block and blockquote background      |
+| `--pk-space-lg`             | Blockquote horizontal padding             |
+| `--pk-space-sm`             | List icon right margin                    |
+| `--pk-space-xs`             | List item bottom gap                      |
+| `--pk-radius-sm`            | Code block corner radius                  |
+| `--pk-radius-md`            | Inline image corner radius                |
+| `--pk-palette-white`        | Ordered list marker text color            |
 
 ---
 

--- a/docs/docs/design-tokens.mdx
+++ b/docs/docs/design-tokens.mdx
@@ -54,7 +54,8 @@ import "@prokodo/ui/theme-tokens.css"
 | `--pk-color-surface`    | `#f9fafb` | Card / panel background |
 | `--pk-color-border`     | `#e5e7eb` | Dividers, input borders |
 | `--pk-color-text`       | `#111827` | Body text               |
-| `--pk-color-text-muted` | `#4d4d4d` | Secondary text          |
+| `--pk-color-text-muted` | `#425263` | Secondary text          |
+| `--pk-color-emphasis`   | `#16212b` | Bold / strong text      |
 
 ---
 

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/components/rich-text.mdx
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/components/rich-text.mdx
@@ -56,8 +56,8 @@ import "@prokodo/ui/rich-text.css"
 | Token                       | Beschreibung                                     |
 | --------------------------- | ------------------------------------------------ |
 | `--pk-color-brand`          | Linkfarbe und Listenmarkierung (geordnete Liste) |
-| `--pk-color-muted`          | Text- und Code-Farbe                             |
-| `--pk-color-fg`             | Listenelement-Textfarbe                          |
+| `--pk-color-muted`          | Text-, Code- und Listenelement-Farbe             |
+| `--pk-color-emphasis`       | Farbe für fetten / hervorgehobenen Text          |
 | `--pk-color-border`         | Rahmen bei Codeblock und Blockquote              |
 | `--pk-color-surface-raised` | Hintergrund von Codeblock und Blockquote         |
 | `--pk-space-lg`             | Horizontales Padding des Blockquote              |

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/design-tokens.mdx
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/design-tokens.mdx
@@ -40,14 +40,15 @@ Diese Tokens überschreibst du, um deine Marke anzuwenden.
 
 ### Oberfläche & Vordergrund
 
-| Token                       | Hell      | Dunkel    | Beschreibung                         |
-| --------------------------- | --------- | --------- | ------------------------------------ |
-| `--pk-color-bg`             | `#f5f5f5` | `#121212` | Seitenhintergrund                    |
-| `--pk-color-fg`             | `#121212` | `#f5f5f5` | Primärer Text / Icons                |
-| `--pk-color-surface`        | `#ffffff` | `#242424` | Karte, Input, Panel-Hintergrund      |
-| `--pk-color-surface-raised` | `#f5f5f5` | `#2f2f2f` | Erhöhte Oberfläche (Button-Standard) |
-| `--pk-color-border`         | `#9c9c9c` | `#393939` | Trennlinien, Input-Rahmen            |
-| `--pk-color-muted`          | `#4d4d4d` | `#9c9c9c` | Placeholder / sekundärer Label-Text  |
+| Token                       | Hell      | Dunkel    | Beschreibung                             |
+| --------------------------- | --------- | --------- | ---------------------------------------- |
+| `--pk-color-bg`             | `#f5f5f5` | `#121212` | Seitenhintergrund                        |
+| `--pk-color-fg`             | `#121212` | `#f5f5f5` | Primärer Text / Icons                    |
+| `--pk-color-surface`        | `#ffffff` | `#242424` | Karte, Input, Panel-Hintergrund          |
+| `--pk-color-surface-raised` | `#f5f5f5` | `#2f2f2f` | Erhöhte Oberfläche (Button-Standard)     |
+| `--pk-color-border`         | `#9c9c9c` | `#393939` | Trennlinien, Input-Rahmen                |
+| `--pk-color-muted`          | `#425263` | `#92a2b3` | Placeholder / sekundärer Label-Text      |
+| `--pk-color-emphasis`       | `#16212b` | `#d9e2ec` | Hervorgehobener Text (fett / `<strong>`) |
 
 ### Status
 

--- a/src/components/rich-text/RichText.docs.mdx
+++ b/src/components/rich-text/RichText.docs.mdx
@@ -52,7 +52,8 @@ Key `--pk-*` tokens used by this component:
 | Token                       | Purpose                                       |
 | --------------------------- | --------------------------------------------- |
 | `--pk-color-brand`          | Anchor color, ordered-list decimal background |
-| `--pk-color-muted`          | Paragraph and preformatted text color         |
+| `--pk-color-muted`          | Paragraph, code, and list item text color     |
+| `--pk-color-emphasis`       | Bold / strong text color                      |
 | `--pk-color-border`         | `<pre>` border, blockquote left border        |
 | `--pk-color-surface-raised` | `<pre>` and blockquote background             |
 | `--pk-radius-sm`            | `<pre>` block border-radius                   |

--- a/src/components/rich-text/RichText.module.scss
+++ b/src/components/rich-text/RichText.module.scss
@@ -7,6 +7,11 @@
 @include define-block("RichText") {
     &__a {
         color: var(--pk-color-brand);
+
+        b,
+        strong {
+            color: var(--pk-color-brand) !important;
+        }
     }
 
     &__p {
@@ -15,6 +20,11 @@
 
         & {
             text-align: inherit;
+        }
+
+        b,
+        strong {
+            color: var(--pk-color-emphasis);
         }
     }
 
@@ -81,7 +91,12 @@
             overflow-wrap: anywhere;
             display: inline;
             @include text("base");
-            & { color: var(--pk-color-fg); }
+            & { color: var(--pk-color-muted); }
+
+            b,
+            strong {
+                color: var(--pk-color-emphasis);
+            }
         }
     }
 

--- a/src/components/rich-text/RichText.stories.tsx
+++ b/src/components/rich-text/RichText.stories.tsx
@@ -47,11 +47,11 @@ const sampleMarkdown = `
 Lorem ipsum **dolor sit amet**, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna *aliquyam erat*, sed diam voluptua.
 
-- Item one
-- Item two
+- **Item one**
+- _Item two_
 - Item three
 
-> Blockquote example with some notable text.
+> Blockquote **example** with some notable text.
 
 \`\`\`ts
 const greet = (name: string) => \`Hello, \${name}!\`
@@ -81,7 +81,7 @@ export const SecondaryVariant: Story = {
 
 export const WithLink: Story = {
   args: {
-    children: `Visit [prokodo.com](https://www.prokodo.com) for more information.`,
+    children: `Visit [prokodo.com](https://www.prokodo.com) and [**prokodo.com**](https://www.prokodo.com) for more information.`,
   },
 }
 

--- a/src/components/table/Table.module.scss
+++ b/src/components/table/Table.module.scss
@@ -14,6 +14,8 @@
 @include define-block("Table") {
   padding-bottom: var(--pk-table-container-pb);
   padding-left: calc(var(--pk-space-lg) + var(--pk-space-xs));
+  min-width: 0;
+  overflow: hidden;
 
   @include screenLargerThan($screen-md) {
     padding-left: 0;

--- a/src/styles/tokens/_semantic.scss
+++ b/src/styles/tokens/_semantic.scss
@@ -45,7 +45,8 @@
     --pk-color-surface:        var(--pk-palette-white);
     --pk-color-surface-raised: var(--pk-palette-grey-50);
     --pk-color-border:         var(--pk-palette-grey-200);
-    --pk-color-muted:          var(--pk-palette-grey-500);
+    --pk-color-muted:          #425263;
+    --pk-color-emphasis:       #16212b;
     --pk-color-overlay-alpha:  0.5;
 
     // Shared semantic — only emitted in light (not overridden in dark)
@@ -106,7 +107,8 @@
     --pk-color-surface:        var(--pk-palette-slate-950);
     --pk-color-surface-raised: var(--pk-palette-grey-800);
     --pk-color-border:         var(--pk-palette-grey-700);
-    --pk-color-muted:          var(--pk-palette-grey-200);
+    --pk-color-muted:          #92a2b3;
+    --pk-color-emphasis:       #d9e2ec;
     --pk-color-overlay-alpha:  0.7;
   }
 }


### PR DESCRIPTION
- Change --pk-color-muted to #425263 (light) / #92a2b3 (dark)
- Add --pk-color-emphasis token #16212b (light) / #d9e2ec (dark)
- Apply --pk-color-muted to RichText li__content (was --pk-color-fg)
- Apply --pk-color-emphasis to bold/strong in RichText p and li
- Preserve brand color on bold text inside links
- Add overflow protection to Table component
- Update design-tokens and RichText docs (EN + DE)
- Update RichText stories with bold examples